### PR TITLE
Add llm option

### DIFF
--- a/lib/agent_chain.ex
+++ b/lib/agent_chain.ex
@@ -53,6 +53,7 @@ Here is the output schema:
 
   - `:verbose` - Runs the LLM in verbose mode if set to true. Defaults to `false`.
   - `:stream_handler` - Handler that is called as the LLM returns messages.
+  - `:llm` - A LangChain chat model.
 
   """
   @spec new!(opts :: keyword()) :: t()
@@ -65,10 +66,9 @@ Here is the output schema:
     callback =
       if stream_handler != nil, do: stream_handler, else: get_default_stream_handler()
 
-    # TODO: pull this default llm from a config
     wrapped_chain =
       %{
-        llm: get_default_llm(),
+        llm: opts[:llm] || get_default_llm(),
         verbose: opts[:verbose]
       }
       |> LLMChain.new!()

--- a/lib/agent_executor.ex
+++ b/lib/agent_executor.ex
@@ -164,7 +164,7 @@ defmodule Magus.AgentExecutor do
         end
       }
 
-      chain = AgentChain.new!(stream_handler: log_handler)
+      chain = AgentChain.new!(llm: agent.llm, stream_handler: log_handler)
 
       # Retry up to 3 times if we get an error
       # TODO: Make this more configurable

--- a/lib/agent_executor_lite.ex
+++ b/lib/agent_executor_lite.ex
@@ -19,7 +19,7 @@ defmodule Magus.AgentExecutorLite do
   defp do_step(%GraphAgent{} = agent, cur_state, cur_node) do
     cur_node_fn = agent.node_to_fn[cur_node]
 
-    chain = Magus.AgentChain.new!()
+    chain = Magus.AgentChain.new!(llm: agent.llm)
     next_state = cur_node_fn.(chain, cur_state)
 
     # Find next edge to go to

--- a/lib/graph_agent.ex
+++ b/lib/graph_agent.ex
@@ -9,7 +9,8 @@ defmodule Magus.GraphAgent do
     final_output_property: nil,
     node_to_fn: %{},
     node_to_conditional_fn: %{},
-    cleanup_fn: nil
+    cleanup_fn: nil,
+    llm: nil
   ]
 
   @type t() :: %GraphAgent{}


### PR DESCRIPTION
Make the LLM fully customizable. And no need to maintain llm options in this project.

It's backward compatible, so when the `llm` option is not set the old defaults will be applied.